### PR TITLE
refactor: makeModule 함수에 name argument값을 열거형으로 변경 (#22)

### DIFF
--- a/Projects/Core/Project.swift
+++ b/Projects/Core/Project.swift
@@ -8,9 +8,10 @@
 
 import ProjectDescription
 import ProjectDescriptionHelpers
+import DependencyPlugin
 
 let project = Project.makeModule(
-    name: "Core",
+    name: ModulePaths.CoreModule.Core.rawValue,
     targets: [
         .implements(
             modulePath: .core(.Core),

--- a/Projects/Domain/Project.swift
+++ b/Projects/Domain/Project.swift
@@ -7,9 +7,10 @@
 
 import ProjectDescription
 import ProjectDescriptionHelpers
+import DependencyPlugin
 
 let project = Project.makeModule(
-    name: "Domain",
+    name: ModulePaths.DomainModule.Domain.rawValue,
     targets: [
         .implements(
             modulePath: .domain(.Domain),

--- a/Projects/Feature/Project.swift
+++ b/Projects/Feature/Project.swift
@@ -7,9 +7,10 @@
 
 import ProjectDescription
 import ProjectDescriptionHelpers
+import DependencyPlugin
 
 let project = Project.makeModule(
-    name: "Feature",
+    name: ModulePaths.FeatureModule.Feature.rawValue,
     resources: ["Resources/**"],
     targets: [
         .implements(

--- a/Projects/Feature/RootFeature/Project.swift
+++ b/Projects/Feature/RootFeature/Project.swift
@@ -6,12 +6,11 @@
 //
 
 import ProjectDescription
-import DependencyPlugin
 import ProjectDescriptionHelpers
-import EnvironmentPlugin
+import DependencyPlugin
 
 let project = Project.makeModule(
-    name: "RootFeature",
+    name: ModulePaths.FeatureModule.RootFeature.rawValue,
     targets: [
         .implements(
             modulePath: .feature(.RootFeature),

--- a/Projects/Shared/CommonUI/Project.swift
+++ b/Projects/Shared/CommonUI/Project.swift
@@ -8,9 +8,10 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 import EnvironmentPlugin
+import DependencyPlugin
 
 let project = Project.makeModule(
-    name: "CommonUI",
+    name: ModulePaths.SharedModule.CommonUI.rawValue,
     resources: ["Resources/**"],
     targets: [
         .implements(

--- a/Projects/Shared/Project.swift
+++ b/Projects/Shared/Project.swift
@@ -7,9 +7,10 @@
 
 import ProjectDescription
 import ProjectDescriptionHelpers
+import DependencyPlugin
 
 let project = Project.makeModule(
-    name: "Shared",
+    name: ModulePaths.SharedModule.ThirdPartyLibrary.rawValue,
     targets: [
         .implements(
             modulePath: .shared(.Shared),


### PR DESCRIPTION
**설명**

`makeModule` 함수의 `name` 아그먼트를 문자열에서 열거형 값으로 변경하여 타입 안전성을 강화합니다. 이 변경은 코드의 일관성을 높이고, 오타 발생을 줄이는 데 도움이 됩니다.

**변경 사항**
- `makeModule` 함수의 `name` 아그먼트를 열거형 값으로 변경
- `ModulePaths` 사용
